### PR TITLE
Fixed Prototype Pollution

### DIFF
--- a/client/js/util.js
+++ b/client/js/util.js
@@ -443,6 +443,12 @@ var qq = function(element) {
     };
 
     qq.extend = function(first, second, extendNested) {
+        var key = String(Object.keys(second));
+
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+            return first;
+        }
+
         qq.each(second, function(prop, val) {
             if (extendNested && qq.isObject(val)) {
                 if (first[prop] === undefined) {

--- a/client/js/util.js
+++ b/client/js/util.js
@@ -445,9 +445,8 @@ var qq = function(element) {
     qq.extend = function(first, second, extendNested) {
         var key = String(Object.keys(second));
 
-        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')) 
             return first;
-        }
 
         qq.each(second, function(prop, val) {
             if (extendNested && qq.isObject(val)) {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-fine-uploader

### ⚙️ Description *

The project `fine-uploader` was modifying two-input `Object`s without any validation causing a **Prototype Pollution**.

### 💻 Technical Description *

The function `qq.extend()` function is accepting three arguments `first`, `second`, and `extendNested`. The first two arguments are expecting `Object`s, if we pass in a prototype in the second `Object`, it would be _copied_ to the first `Object` causing a Prototype Pollution.

### 🐛 Proof of Concept (PoC) *

```javascript
var payload = JSON.parse('{"proto": {"a": "polluted"}}');
var new = qq.extend({}, payload);
console.log({}.a);
```

### 🔥 Proof of Fix (PoF) *

```javascript
var key = String(Object.keys(second));

if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype'))
    return first;
```

Added key checks on the second input `Object` to check for all the keywords used to create a `prototype`.

This is the same fix implemented by **Lodash**: https://github.com/lodash/lodash/commit/c84fe82760fb2d3e03a63379b297a1cc1a2fce12

### 👍 User Acceptance Testing (UAT)

_Just added a string check for `prototype` keywords in input `Object`s._